### PR TITLE
Correction of two bugs related to startup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,9 @@ License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
+Depends:
+    utils
 Imports: 
     pkgload,
-    utils,
     yaml
 URL: https://eliocamp.github.io/rhelpi18n/

--- a/R/zzzz.R
+++ b/R/zzzz.R
@@ -1,4 +1,11 @@
 .onLoad <- function(libname, pkgname){
+  # We need to explicitly set language, otherwise there is a problem in RStudio:
+  # error in strsplit(target_language, ":")[[1]][[1]] : subscript out of bound
+  # when running resolve_lang()
+  if (is.na(Sys.getenv("LANGUAGE", NA)))
+    Sys.setLanguage("en")
+
+  library(utils) # Apparently required for R CMD check despite Depends: utils ?!
   utils <- asNamespace('utils')
 
   package_env <- as.environment('package:utils')


### PR DESCRIPTION

(1) utils is not necessarily on the search() path -> `as.environment('package:utils')` fails in that case. {utils} must be in Depends, not Imports in the DESCRIPTION file if 'package:utils' is supposed to exist. Moreover, I also had to use `library(utils)` in `.onLoad()` to make sure it is OK.

(2) If the LANGUAGE environment variable is not set, RStudio cannot resolve function names/man pages. The error is in `resolve_lang()`: **error in strsplit(target_language, ":")[[1]][[1]] : subscript out of bound**, but making sure the LANGUAGE environment variable is set (to `"en"` by default) is enough to solve this problem.