### PR TITLE
Dynamic sexpr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,8 +13,10 @@ RoxygenNote: 7.3.2
 Depends: 
     R (>= 4.3.0),
     utils
-Imports: 
+Imports:
     pkgload,
     yaml,
     whisker
+Suggests:
+    testit
 URL: https://eliocamp.github.io/rhelpi18n/

--- a/R/rd-flatten.R
+++ b/R/rd-flatten.R
@@ -95,6 +95,13 @@ to_text <- function(x) {
   if (length(x) == 0) {
     return("")
   }
+  # A USERMACRO node is a provenance marker that holds a copy of the macro's
+  # (unsubstituted) body; the actual expansion follows as sibling nodes. Emitting
+  # the marker too would duplicate the expansion (e.g. "GSoCGSoC") and leak raw
+  # "#1" args, so skip it.
+  if (identical(tag, "USERMACRO")) {
+    return("")
+  }
   if (is.character(x) || !is.null(tag) && !startsWith(tag, "\\")) {
     return(x[[1]])
   }

--- a/R/rd-flatten.R
+++ b/R/rd-flatten.R
@@ -102,7 +102,10 @@ to_text <- function(x) {
   if (identical(tag, "USERMACRO")) {
     return("")
   }
-  if (is.character(x) || !is.null(tag) && !startsWith(tag, "\\")) {
+  # #ifdef / #ifndef are two-argument list nodes; deparse them (like markup
+  # macros) instead of returning x[[1]], which is a list and errored.
+  is_ifdef <- !is.null(tag) && tag %in% c("#ifdef", "#ifndef")
+  if (!is_ifdef && (is.character(x) || !is.null(tag) && !startsWith(tag, "\\"))) {
     return(x[[1]])
   }
   text <- as.character(setRd(x), deparse = TRUE)

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -73,9 +73,31 @@ translate <- function(original, translation) {
 # braces, `{{ISEXPR_n}}`. Such literals are hidden behind sentinels before any token
 # work (so only real, single-brace placeholders are matched) and restored as a
 # single-brace literal in the output.
-match_and_fill <- function(live, stored, translation, ifdef = NULL) {
+match_and_fill <- function(live, stored, translation, ifdef = NULL,
+                           details = FALSE) {
+  tok_re  <- "\\{ISEXPR_[0-9]+\\}"
+  stored0 <- stored   # original scaffold, kept for the optional status metadata
+
+  # Default: return the bare string (unchanged). details = TRUE instead returns
+  # list(text, reason, distance):
+  #   reason   "valid"        scaffold matched, translation applied
+  #            "stale"        a translation exists but `live` drifted from it
+  #            "untranslated" no translation to apply
+  #   distance 0 for "valid"; a coarse Levenshtein drift of `live` from the
+  #            scaffold skeleton for "stale"; NA otherwise. Nothing here reads
+  #            these — forward-looking metadata for a future soft-fallback / tool.
+  finish <- function(text, reason) {
+    if (!details) return(text)
+    skeleton <- if (is.null(stored0)) "" else gsub(tok_re, "", stored0)
+    distance <- switch(reason,
+                       valid = 0L,
+                       stale = as.integer(utils::adist(live, skeleton)[1, 1]),
+                       NA_integer_)
+    list(text = text, reason = reason, distance = distance)
+  }
+
   if (is.null(stored) || is.null(translation)) {
-    return(live)
+    return(finish(live, "untranslated"))
   }
 
   hide   <- function(s) gsub("\\{\\{(ISEXPR_[0-9]+)\\}\\}", "\x01\\1\x02", s)
@@ -83,14 +105,12 @@ match_and_fill <- function(live, stored, translation, ifdef = NULL) {
   stored      <- hide(stored)
   translation <- hide(translation)
 
-  tok_re <- "\\{ISEXPR_[0-9]+\\}"
-
   # No placeholders -> plain exact-match (backward compatible).
   if (!grepl(tok_re, stored)) {
     if (identical(live, reveal(stored))) {
-      return(reveal(translation))
+      return(finish(reveal(translation), "valid"))
     }
-    return(live)
+    return(finish(live, "stale"))
   }
 
   toks <- regmatches(stored, gregexpr(tok_re, stored))[[1]]
@@ -104,7 +124,7 @@ match_and_fill <- function(live, stored, translation, ifdef = NULL) {
 
   # Boundary anchors are pinned to the ends; interior anchors split sequentially.
   if (!startsWith(live, anchors[1])) {
-    return(live)
+    return(finish(live, "stale"))
   }
   rem <- substr(live, nchar(anchors[1]) + 1L, nchar(live))
   values <- character(n)
@@ -113,13 +133,13 @@ match_and_fill <- function(live, stored, translation, ifdef = NULL) {
       a <- anchors[k + 1L]
       if (nchar(a) == 0) { values[k] <- ""; next }    # adjacent tokens, no separator
       p <- regexpr(a, rem, fixed = TRUE)
-      if (p == -1) return(live)
+      if (p == -1) return(finish(live, "stale"))
       values[k] <- substr(rem, 1, p - 1)
       rem <- substr(rem, p + nchar(a), nchar(rem))
     }
   }
   if (!endsWith(rem, anchors[n + 1L])) {
-    return(live)  # scaffold did not match (genuine version drift)
+    return(finish(live, "stale"))  # scaffold did not match (genuine version drift)
   }
   values[n] <- substr(rem, 1, nchar(rem) - nchar(anchors[n + 1L]))
 
@@ -137,6 +157,6 @@ match_and_fill <- function(live, stored, translation, ifdef = NULL) {
     }
     out <- gsub(paste0("{ISEXPR_", idx[k], "}"), val, out, fixed = TRUE)
   }
-  reveal(out)
+  finish(reveal(out), "valid")
 }
 

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -24,24 +24,32 @@ translate <- function(original, translation) {
   for (section in sections)  {
 
     if (is.character(original[[section]]$original)) {
-      version_matches <- original[[section]]$original == translation[[section]]$original
-      translation_exists <- !is.null(translation[[section]]$translation)
+      live   <- original[[section]]$original
+      stored <- translation[[section]]$original
+      trans  <- translation[[section]]$translation
 
-      if (version_matches && translation_exists) {
+      # Token-aware match: stored `original`/`translation` may contain {ISEXPR_i}
+      # placeholders standing in for install/build-Sexpr-baked spans (whose value
+      # changes every install). match_and_fill() matches the live `original`
+      # against the stored scaffold as a template, captures the live values, and
+      # substitutes them into the translation. With no tokens it is an exact match,
+      # so existing modules behave exactly as before.
+      filled <- if (!is.null(trans)) match_and_fill(live, stored, trans) else NULL
+
+      if (!is.null(filled)) {
         if (section %in% c("examples", "title")) {
           original[[section]] <- paste0(
-            translation[[section]]$translation,
+            filled,
             "\\if{html}{\\out{<details style='display:inline'> <summary>} \U0001f310 \\out{</summary>} ",
-            original[[section]]$original,
+            live,
             "\\out{</details>}}")
         } else {
-          original[[section]] <- translation[[section]]$translation
+          original[[section]] <- filled
         }
 
       } else {
-        # If the translation is out of date?
-        # For now, keep the original
-        original[[section]] <- original[[section]]$original
+        # Translation missing or out of date: keep the original
+        original[[section]] <- live
       }
     }
 
@@ -52,5 +60,46 @@ translate <- function(original, translation) {
 
   }
   return(original)
+}
+
+# Match a live (baked) section string against a stored scaffold template and fill
+# the translation. The scaffold may contain {ISEXPR_i} placeholders for dynamic
+# (install/build-Sexpr) spans; each becomes a capture group, and the captured live
+# value is substituted into the matching {ISEXPR_i} in the translation.
+# Returns the filled translation, or NULL if it does not match.
+match_and_fill <- function(live, stored, translation) {
+  if (is.null(stored) || is.null(translation)) {
+    return(NULL)
+  }
+  tok_re <- "\\{ISEXPR_([0-9]+)\\}"
+
+  # No placeholders -> plain exact-match (backward compatible).
+  if (!grepl(tok_re, stored)) {
+    if (identical(live, stored)) {
+      return(translation)
+    }
+    return(NULL)
+  }
+
+  esc <- function(x) gsub("([][{}()*+?.\\\\^$|])", "\\\\\\1", x, perl = TRUE)
+  toks <- regmatches(stored, gregexpr(tok_re, stored))[[1]]
+  idx  <- as.integer(sub(tok_re, "\\1", toks))
+  lits <- strsplit(stored, tok_re, perl = TRUE)[[1]]
+  if (length(lits) < length(toks) + 1) {
+    lits <- c(lits, rep("", length(toks) + 1 - length(lits)))
+  }
+  re <- paste0("^", paste0(vapply(lits, esc, character(1)), collapse = "(.*?)"), "$")
+
+  caps <- regmatches(live, regexec(re, live, perl = TRUE))[[1]]
+  if (length(caps) == 0) {
+    return(NULL)  # scaffold did not match (genuine version drift)
+  }
+  values <- caps[-1]
+
+  out <- translation
+  for (k in seq_along(idx)) {
+    out <- gsub(paste0("{ISEXPR_", idx[k], "}"), values[k], out, fixed = TRUE)
+  }
+  out
 }
 

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -33,25 +33,20 @@ translate <- function(original, translation) {
       # changes every install). match_and_fill() matches the live `original`
       # against the stored scaffold as a template, captures the live values, and
       # substitutes them into the translation. With no tokens it is an exact match,
-      # so existing modules behave exactly as before.
-      filled <- if (!is.null(trans)) match_and_fill(live, stored, trans,
-                                                    translation[[section]]$ifdef) else NULL
+      # so existing modules behave exactly as before. When no translation applies
+      # (missing, or an out-of-date scaffold) it returns `live` unchanged.
+      filled <- match_and_fill(live, stored, trans, translation[[section]]$ifdef)
 
-      if (!is.null(filled)) {
-        if (section %in% c("examples", "title")) {
-          original[[section]] <- paste0(
-            filled,
-            "\\if{html}{\\out{<details style='display:inline'> <summary>} \U0001f310 \\out{</summary>} ",
-            live,
-            "\\out{</details>}}")
-        } else {
-          original[[section]] <- filled
-        }
-
-      } else {
-        # Translation missing or out of date: keep the original
-        original[[section]] <- live
+      # examples/title that were actually translated show the original collapsed
+      # behind a disclosure; an untranslated section is just `live`.
+      if (!identical(filled, live) && section %in% c("examples", "title")) {
+        filled <- paste0(
+          filled,
+          "\\if{html}{\\out{<details style='display:inline'> <summary>} \U0001f310 \\out{</summary>} ",
+          live,
+          "\\out{</details>}}")
       }
+      original[[section]] <- filled
     }
 
     if (is.list(original[[section]])) {
@@ -69,10 +64,12 @@ translate <- function(original, translation) {
 # `live` by fixed-string search (no regex escaping, and it spans newlines, so
 # multi-line baked output works); the gaps are the captured live values, which are
 # substituted into the matching {ISEXPR_i} in the translation.
-# Returns the filled translation, or NULL if the scaffold does not match.
+# Returns the filled translation, or `live` unchanged if the scaffold does not
+# match (missing translation, or genuine version drift) — so the caller can use
+# the result directly with no NULL check.
 match_and_fill <- function(live, stored, translation, ifdef = NULL) {
   if (is.null(stored) || is.null(translation)) {
-    return(NULL)
+    return(live)
   }
   tok_re <- "\\{ISEXPR_[0-9]+\\}"
 
@@ -81,7 +78,7 @@ match_and_fill <- function(live, stored, translation, ifdef = NULL) {
     if (identical(live, stored)) {
       return(translation)
     }
-    return(NULL)
+    return(live)
   }
 
   toks <- regmatches(stored, gregexpr(tok_re, stored))[[1]]
@@ -94,7 +91,7 @@ match_and_fill <- function(live, stored, translation, ifdef = NULL) {
 
   # Boundary anchors are pinned to the ends; interior anchors split sequentially.
   if (!startsWith(live, anchors[1])) {
-    return(NULL)
+    return(live)
   }
   rem <- substr(live, nchar(anchors[1]) + 1L, nchar(live))
   values <- character(n)
@@ -103,13 +100,13 @@ match_and_fill <- function(live, stored, translation, ifdef = NULL) {
       a <- anchors[k + 1L]
       if (nchar(a) == 0) { values[k] <- ""; next }    # adjacent tokens, no separator
       p <- regexpr(a, rem, fixed = TRUE)
-      if (p == -1) return(NULL)
+      if (p == -1) return(live)
       values[k] <- substr(rem, 1, p - 1)
       rem <- substr(rem, p + nchar(a), nchar(rem))
     }
   }
   if (!endsWith(rem, anchors[n + 1L])) {
-    return(NULL)  # scaffold did not match (genuine version drift)
+    return(live)  # scaffold did not match (genuine version drift)
   }
   values[n] <- substr(rem, 1, nchar(rem) - nchar(anchors[n + 1L]))
 

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -67,16 +67,28 @@ translate <- function(original, translation) {
 # Returns the filled translation, or `live` unchanged if the scaffold does not
 # match (missing translation, or genuine version drift) — so the caller can use
 # the result directly with no NULL check.
+#
+# A *literal* placeholder-shaped string (which reaches the flattened help only via
+# Rd-escaped braces, `\{ISEXPR_n\}`) is authored in the stored strings with doubled
+# braces, `{{ISEXPR_n}}`. Such literals are hidden behind sentinels before any token
+# work (so only real, single-brace placeholders are matched) and restored as a
+# single-brace literal in the output.
 match_and_fill <- function(live, stored, translation, ifdef = NULL) {
   if (is.null(stored) || is.null(translation)) {
     return(live)
   }
+
+  hide   <- function(s) gsub("\\{\\{(ISEXPR_[0-9]+)\\}\\}", "\x01\\1\x02", s)
+  reveal <- function(s) gsub("\x02", "}", gsub("\x01", "{", s, fixed = TRUE), fixed = TRUE)
+  stored      <- hide(stored)
+  translation <- hide(translation)
+
   tok_re <- "\\{ISEXPR_[0-9]+\\}"
 
   # No placeholders -> plain exact-match (backward compatible).
   if (!grepl(tok_re, stored)) {
-    if (identical(live, stored)) {
-      return(translation)
+    if (identical(live, reveal(stored))) {
+      return(reveal(translation))
     }
     return(live)
   }
@@ -88,6 +100,7 @@ match_and_fill <- function(live, stored, translation, ifdef = NULL) {
   if (length(anchors) < n + 1L) {
     anchors <- c(anchors, rep("", n + 1L - length(anchors)))  # strsplit drops trailing ""
   }
+  anchors <- reveal(anchors)   # a literal {ISEXPR_n} in an anchor matches the live text
 
   # Boundary anchors are pinned to the ends; interior anchors split sequentially.
   if (!startsWith(live, anchors[1])) {
@@ -124,6 +137,6 @@ match_and_fill <- function(live, stored, translation, ifdef = NULL) {
     }
     out <- gsub(paste0("{ISEXPR_", idx[k], "}"), val, out, fixed = TRUE)
   }
-  out
+  reveal(out)
 }
 

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -34,7 +34,8 @@ translate <- function(original, translation) {
       # against the stored scaffold as a template, captures the live values, and
       # substitutes them into the translation. With no tokens it is an exact match,
       # so existing modules behave exactly as before.
-      filled <- if (!is.null(trans)) match_and_fill(live, stored, trans) else NULL
+      filled <- if (!is.null(trans)) match_and_fill(live, stored, trans,
+                                                    translation[[section]]$ifdef) else NULL
 
       if (!is.null(filled)) {
         if (section %in% c("examples", "title")) {
@@ -69,7 +70,7 @@ translate <- function(original, translation) {
 # multi-line baked output works); the gaps are the captured live values, which are
 # substituted into the matching {ISEXPR_i} in the translation.
 # Returns the filled translation, or NULL if the scaffold does not match.
-match_and_fill <- function(live, stored, translation) {
+match_and_fill <- function(live, stored, translation, ifdef = NULL) {
   if (is.null(stored) || is.null(translation)) {
     return(NULL)
   }
@@ -114,7 +115,17 @@ match_and_fill <- function(live, stored, translation) {
 
   out <- translation
   for (k in seq_along(idx)) {
-    out <- gsub(paste0("{ISEXPR_", idx[k], "}"), values[k], out, fixed = TRUE)
+    val <- values[k]
+    key <- as.character(idx[k])
+    # An #ifdef token whose live value is the active branch (not R's
+    # "#ifdef <cond> not active" marker) is replaced by its stored branch
+    # translation; an inactive branch keeps the (invisible) marker, and a plain
+    # install/build span keeps its captured value (passthrough).
+    if (!is.null(ifdef) && key %in% names(ifdef) &&
+        !grepl("^#if(n?)def .* not active", val)) {
+      val <- ifdef[[key]]
+    }
+    out <- gsub(paste0("{ISEXPR_", idx[k], "}"), val, out, fixed = TRUE)
   }
   out
 }

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -64,14 +64,16 @@ translate <- function(original, translation) {
 
 # Match a live (baked) section string against a stored scaffold template and fill
 # the translation. The scaffold may contain {ISEXPR_i} placeholders for dynamic
-# (install/build-Sexpr) spans; each becomes a capture group, and the captured live
-# value is substituted into the matching {ISEXPR_i} in the translation.
-# Returns the filled translation, or NULL if it does not match.
+# (install/build-Sexpr) spans. The literal text between tokens is matched against
+# `live` by fixed-string search (no regex escaping, and it spans newlines, so
+# multi-line baked output works); the gaps are the captured live values, which are
+# substituted into the matching {ISEXPR_i} in the translation.
+# Returns the filled translation, or NULL if the scaffold does not match.
 match_and_fill <- function(live, stored, translation) {
   if (is.null(stored) || is.null(translation)) {
     return(NULL)
   }
-  tok_re <- "\\{ISEXPR_([0-9]+)\\}"
+  tok_re <- "\\{ISEXPR_[0-9]+\\}"
 
   # No placeholders -> plain exact-match (backward compatible).
   if (!grepl(tok_re, stored)) {
@@ -81,20 +83,34 @@ match_and_fill <- function(live, stored, translation) {
     return(NULL)
   }
 
-  esc <- function(x) gsub("([][{}()*+?.\\\\^$|])", "\\\\\\1", x, perl = TRUE)
   toks <- regmatches(stored, gregexpr(tok_re, stored))[[1]]
-  idx  <- as.integer(sub(tok_re, "\\1", toks))
-  lits <- strsplit(stored, tok_re, perl = TRUE)[[1]]
-  if (length(lits) < length(toks) + 1) {
-    lits <- c(lits, rep("", length(toks) + 1 - length(lits)))
+  idx  <- as.integer(sub("\\{ISEXPR_([0-9]+)\\}", "\\1", toks))
+  n    <- length(toks)
+  anchors <- strsplit(stored, tok_re)[[1]]            # n+1 literal anchors
+  if (length(anchors) < n + 1L) {
+    anchors <- c(anchors, rep("", n + 1L - length(anchors)))  # strsplit drops trailing ""
   }
-  re <- paste0("^", paste0(vapply(lits, esc, character(1)), collapse = "(.*?)"), "$")
 
-  caps <- regmatches(live, regexec(re, live, perl = TRUE))[[1]]
-  if (length(caps) == 0) {
+  # Boundary anchors are pinned to the ends; interior anchors split sequentially.
+  if (!startsWith(live, anchors[1])) {
+    return(NULL)
+  }
+  rem <- substr(live, nchar(anchors[1]) + 1L, nchar(live))
+  values <- character(n)
+  if (n >= 2L) {
+    for (k in 1:(n - 1L)) {
+      a <- anchors[k + 1L]
+      if (nchar(a) == 0) { values[k] <- ""; next }    # adjacent tokens, no separator
+      p <- regexpr(a, rem, fixed = TRUE)
+      if (p == -1) return(NULL)
+      values[k] <- substr(rem, 1, p - 1)
+      rem <- substr(rem, p + nchar(a), nchar(rem))
+    }
+  }
+  if (!endsWith(rem, anchors[n + 1L])) {
     return(NULL)  # scaffold did not match (genuine version drift)
   }
-  values <- caps[-1]
+  values[n] <- substr(rem, 1, nchar(rem) - nchar(anchors[n + 1L]))
 
   out <- translation
   for (k in seq_along(idx)) {

--- a/R/rd-translate.R
+++ b/R/rd-translate.R
@@ -35,7 +35,7 @@ translate <- function(original, translation) {
       # substitutes them into the translation. With no tokens it is an exact match,
       # so existing modules behave exactly as before. When no translation applies
       # (missing, or an out-of-date scaffold) it returns `live` unchanged.
-      filled <- match_and_fill(live, stored, trans, translation[[section]]$ifdef)
+      filled <- match_and_fill(live, stored, trans, translation[[section]]$ifdef)$text
 
       # examples/title that were actually translated show the original collapsed
       # behind a disclosure; an untranslated section is just `live`.
@@ -73,26 +73,24 @@ translate <- function(original, translation) {
 # braces, `{{ISEXPR_n}}`. Such literals are hidden behind sentinels before any token
 # work (so only real, single-brace placeholders are matched) and restored as a
 # single-brace literal in the output.
-match_and_fill <- function(live, stored, translation, ifdef = NULL,
-                           details = FALSE) {
+match_and_fill <- function(live, stored, translation, ifdef = NULL) {
   tok_re  <- "\\{ISEXPR_[0-9]+\\}"
-  stored0 <- stored   # original scaffold, kept for the optional status metadata
+  stored0 <- stored   # original scaffold, kept for the status metadata
 
-  # Default: return the bare string (unchanged). details = TRUE instead returns
-  # list(text, reason, distance):
+  # Always returns list(text, reason, distance). Callers currently read only
+  # `text`; reason/distance are non-read metadata for a future soft-fallback / tool.
   #   reason   "valid"        scaffold matched, translation applied
   #            "stale"        a translation exists but `live` drifted from it
   #            "untranslated" no translation to apply
   #   distance 0 for "valid"; a coarse Levenshtein drift of `live` from the
-  #            scaffold skeleton for "stale"; NA otherwise. Nothing here reads
-  #            these — forward-looking metadata for a future soft-fallback / tool.
+  #            scaffold skeleton for "stale"; Inf when there is no translation
+  #            (so 0 / finite / Inf all compare numerically).
   finish <- function(text, reason) {
-    if (!details) return(text)
     skeleton <- if (is.null(stored0)) "" else gsub(tok_re, "", stored0)
     distance <- switch(reason,
-                       valid = 0L,
-                       stale = as.integer(utils::adist(live, skeleton)[1, 1]),
-                       NA_integer_)
+                       valid = 0,
+                       stale = as.numeric(utils::adist(live, skeleton)[1, 1]),
+                       Inf)
     list(text = text, reason = reason, distance = distance)
   }
 

--- a/tests/testit.R
+++ b/tests/testit.R
@@ -1,0 +1,2 @@
+library(testit)
+test_pkg("rhelpi18n")

--- a/tests/testit/test-escaping.R
+++ b/tests/testit/test-escaping.R
@@ -1,0 +1,27 @@
+# {ISEXPR_*} needs no author escaping in normal Rd; only \{ISEXPR_*\} produces a
+# literal, escaped in stored strings as {{ISEXPR_*}}.
+mf         <- rhelpi18n:::match_and_fill
+rd_flatten <- rhelpi18n:::rd_flatten
+
+flatten <- function(body) {
+  f <- tempfile(fileext = ".Rd")
+  writeLines(c("\\name{t}", "\\title{t}", "\\description{", body, "}"), f)
+  trimws(rd_flatten(tools::parse_Rd(f))$description$original)
+}
+
+assert("ordinary prose braces are stripped -> no literal token, no escaping needed", {
+  (!grepl("{ISEXPR_0}", flatten("Here: {ISEXPR_0}."), fixed = TRUE))
+  (grepl("ISEXPR_0", flatten("Here: {ISEXPR_0}."), fixed = TRUE))
+})
+
+assert("Rd-escaped braces \\{ \\} are the only way to emit a literal {ISEXPR_0}", {
+  (grepl("{ISEXPR_0}", flatten("Here: \\{ISEXPR_0\\}."), fixed = TRUE))
+})
+
+assert("a raw literal in a scaffold is mis-read (the exotic collision)", {
+  (grepl("X", mf("Here: X.", "Here: {ISEXPR_0}.", "Aqui: {ISEXPR_0}.")$text, fixed = TRUE))
+})
+
+assert("doubling the braces {{ISEXPR_0}} escapes the literal", {
+  (mf("Here: {ISEXPR_0}.", "Here: {{ISEXPR_0}}.", "Aqui: {{ISEXPR_0}}.")$text == "Aqui: {ISEXPR_0}.")
+})

--- a/tests/testit/test-flatten.R
+++ b/tests/testit/test-flatten.R
@@ -1,0 +1,19 @@
+# rd_flatten / to_text behaviour that the runtime depends on.
+rd_flatten <- rhelpi18n:::rd_flatten
+
+flatten <- function(...) {
+  f <- tempfile(fileext = ".Rd")
+  writeLines(c("\\name{t}", "\\title{t}", "\\description{", ..., "}"), f)
+  rd_flatten(tools::parse_Rd(f))$description$original
+}
+
+assert("#ifdef / #ifndef nodes flatten without error and keep the condition", {
+  (is.character(flatten("Base.", "#ifndef windows", "UNIX LINE.", "#endif", "End.")))
+  (grepl("windows", flatten("Base.", "#ifndef windows", "UNIX LINE.", "#endif", "End."), fixed = TRUE))
+})
+
+assert("a user-defined macro expands exactly once (not doubled)", {
+  out <- flatten("\\newcommand{\\gsoc}{Google Summer of Code}",
+                 "We joined \\gsoc{} in 2026.")
+  (lengths(regmatches(out, gregexpr("Google Summer of Code", out, fixed = TRUE))) == 1L)
+})

--- a/tests/testit/test-match_and_fill.R
+++ b/tests/testit/test-match_and_fill.R
@@ -1,0 +1,56 @@
+# Tests for the runtime placeholder matcher. Strings only, no translation module.
+mf <- rhelpi18n:::match_and_fill
+
+assert("no-token: exact match and drift fallback", {
+  (mf("abc", "abc", "xyz")$text == "xyz")
+  (mf("abd", "abc", "xyz")$text == "abd")
+})
+
+assert("single-token fill (start / end / empty / multiline / regex-literal)", {
+  (mf("on Monday", "on {ISEXPR_0}", "el {ISEXPR_0}")$text == "el Monday")
+  (mf("Xyz", "{ISEXPR_0}yz", "{ISEXPR_0}ZZ")$text == "XZZ")
+  (mf("ab7", "ab{ISEXPR_0}", "cd{ISEXPR_0}")$text == "cd7")
+  (mf("ab", "a{ISEXPR_0}b", "x{ISEXPR_0}y")$text == "xy")
+  (mf("a\nL1\nL2\nb", "a{ISEXPR_0}b", "x{ISEXPR_0}y")$text == "x\nL1\nL2\ny")
+  (mf("id=[a-z]+$", "id={ISEXPR_0}", "id={ISEXPR_0}")$text == "id=[a-z]+$")
+})
+
+assert("multiple and adjacent tokens", {
+  (mf("a1b2c", "a{ISEXPR_0}b{ISEXPR_1}c", "A{ISEXPR_0}B{ISEXPR_1}C")$text == "A1B2C")
+  (mf("xVALy", "x{ISEXPR_0}{ISEXPR_1}y", "p{ISEXPR_0}{ISEXPR_1}q")$text == "pVALq")
+})
+
+assert("scaffold roundtrip: same scaffold as translation reproduces the live", {
+  (mf("Installed on Monday.", "Installed on {ISEXPR_0}.", "Installed on {ISEXPR_0}.")$text ==
+     "Installed on Monday.")
+})
+
+assert("no-match and NULL inputs fall back to live", {
+  (mf("zzz", "a{ISEXPR_0}c", "A{ISEXPR_0}C")$text == "zzz")
+  (mf("a?c", "a{ISEXPR_0}b{ISEXPR_1}c", "A{ISEXPR_0}B{ISEXPR_1}C")$text == "a?c")
+  (mf("aXYd", "a{ISEXPR_0}c", "A{ISEXPR_0}C")$text == "aXYd")
+  (mf("abc", NULL, "xyz")$text == "abc")
+  (mf("abc", "abc", NULL)$text == "abc")
+})
+
+assert("#ifdef: active branch translated, inactive marker kept", {
+  (mf("pre SHOWN post", "pre {ISEXPR_0} post", "PRE {ISEXPR_0} POST",
+      list("0" = "ES"))$text == "PRE ES POST")
+  (mf("pre #ifdef windows not active post", "pre {ISEXPR_0} post", "PRE {ISEXPR_0} POST",
+      list("0" = "ES"))$text == "PRE #ifdef windows not active POST")
+})
+
+assert("literal {{ISEXPR_n}} escaping", {
+  (mf("a {ISEXPR_0} b", "a {{ISEXPR_0}} b", "c {{ISEXPR_0}} d")$text == "c {ISEXPR_0} d")
+  (mf("v=VAL lit={ISEXPR_9}", "v={ISEXPR_0} lit={{ISEXPR_9}}",
+      "x={ISEXPR_0} y={{ISEXPR_9}}")$text == "x=VAL y={ISEXPR_9}")
+})
+
+assert("reason and distance metadata", {
+  (mf("on Monday", "on {ISEXPR_0}", "el {ISEXPR_0}")$reason == "valid")
+  (mf("on Monday", "on {ISEXPR_0}", "el {ISEXPR_0}")$distance == 0)
+  (mf("put at Tuesday", "put on {ISEXPR_0}", "puesto {ISEXPR_0}")$reason == "stale")
+  (mf("put at Tuesday", "put on {ISEXPR_0}", "puesto {ISEXPR_0}")$distance > 0)
+  (mf("on Monday", "on {ISEXPR_0}", NULL)$reason == "untranslated")
+  (is.infinite(mf("on Monday", "on {ISEXPR_0}", NULL)$distance))
+})

--- a/tests/testit/test-resolve-lang.R
+++ b/tests/testit/test-resolve-lang.R
@@ -1,0 +1,26 @@
+# Language resolution against a module's `Language:` field. An exact match wins
+# and is exclusive; otherwise fall back to the root language (split on "_"). This
+# is what keeps zh_CN and zh_TW distinct while sharing the "zh" root.
+rl <- rhelpi18n:::resolve_lang
+
+assert("exact match wins and is exclusive (zh_CN vs zh_TW stay distinct)", {
+  (identical(rl(c("zh_CN", "zh_TW"), "zh_CN"), c(TRUE,  FALSE)))
+  (identical(rl(c("zh_CN", "zh_TW"), "zh_TW"), c(FALSE, TRUE)))
+  (identical(rl(c("es", "en"), "es"), c(TRUE, FALSE)))
+  # an exact hit suppresses the root-language fallback:
+  (identical(rl(c("es_AR", "es_UY", "es"), "es_AR"), c(TRUE, FALSE, FALSE)))
+})
+
+assert("root-language fallback when there is no exact match", {
+  (identical(rl(c("zh_CN", "zh_TW"), "zh"), c(TRUE, TRUE)))                # zh   -> both
+  (identical(rl(c("es_UY", "es_ES", "es"), "es_AR"), c(TRUE, TRUE, TRUE))) # es_AR -> all es*
+  (identical(rl(c("es_AR", "en"), "es"), c(TRUE, FALSE)))                  # es   -> es_AR
+})
+
+assert("no match returns all FALSE", {
+  (identical(rl(c("fr", "de"), "es"), c(FALSE, FALSE)))
+})
+
+assert("a colon-separated LANGUAGE uses its first entry", {
+  (identical(rl(c("en_AU", "es"), "en_AU:en"), c(TRUE, FALSE)))
+})


### PR DESCRIPTION
## Why

`translate()` matches each section by exact string, which breaks on dynamic content:
install-stage `\Sexpr` bakes a value (timestamp, R version) that drifts on reinstall →
section **silently reverts to source language**; `#ifdef`/`#ifndef` make `rd_flatten()`
**error**; user macros are **duplicated** in the flattened text.

## What

A stored `original` may now carry `{ISEXPR_i}` placeholders for dynamic spans. The live
section is matched against this scaffold by **fixed-string anchors**, and the captured
live values are substituted into the translation. **No tokens → exact match as before**,
so existing modules are unaffected.

## Commits

1. `match_and_fill()`: scaffold-template match — install values captured live, survive reinstalls.
2. Fixed-string anchors instead of regex (handles multi-line output, no escaping).
3. Skip `USERMACRO` marker nodes in `to_text()` — stops macro duplication.
4. Deparse `#ifdef`/`#ifndef` in `to_text()` — stops the flatten error.
5. `match_and_fill(ifdef=)` translates the active branch; inactive branches stay invisible.

## Notes

Backward compatible (changes are exact-match fallback + strict fixes). The `{ISEXPR_i}`
scaffolds are produced by a separate module-creation tool (source↔installed diff, no `.Rd`
edits) — not in this PR. Verified end-to-end: `?greet`/`?ifndef` under `LANGUAGE=es` +
a stress harness.